### PR TITLE
fix: return form error messages

### DIFF
--- a/mycarehub/conftest.py
+++ b/mycarehub/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.utils import timezone
 from faker import Faker
 from model_bakery import baker
@@ -72,6 +73,9 @@ def request_with_user(rf, django_user_model, user_with_all_permissions):
     url = settings.ADMIN_URL + "/common/organisation/add/"
     request = rf.get(url)
     request.user = user_with_all_permissions
+    setattr(request, "session", "session")
+    messages = FallbackStorage(request)
+    setattr(request, "_messages", messages)
     return request
 
 

--- a/mycarehub/content/tests/test_wagtail_hooks.py
+++ b/mycarehub/content/tests/test_wagtail_hooks.py
@@ -1,5 +1,4 @@
 import pytest
-from django.core.exceptions import ValidationError
 from django.utils import timezone
 from model_bakery import baker
 from wagtail.models import Page, Site
@@ -24,46 +23,6 @@ pytestmark = pytest.mark.django_db
 def test_get_global_admin_js():
     admin_script = get_global_admin_js()
     assert "DOMContentLoaded" in admin_script
-
-
-def test_before_publish_content_item_audio_video_no_media(
-    request_with_user,
-    content_item_with_tag_and_category,
-):
-    page = content_item_with_tag_and_category
-    page.item_type = "AUDIO_VIDEO"
-    page.save()
-    page.refresh_from_db()
-    assert page.featured_media.count() == 0
-    assert page.item_type == "AUDIO_VIDEO"
-
-    with pytest.raises(ValidationError) as c:
-        before_publish_page(request_with_user, page)
-
-    assert (
-        "an AUDIO_VIDEO content item must have at least one video "
-        "or audio file before publication"
-    ) in str(c.value.messages)
-
-
-def test_before_publish_content_item_pdf_document_no_document(
-    request_with_user,
-    content_item_with_tag_and_category,
-):
-    page = content_item_with_tag_and_category
-    page.item_type = "PDF_DOCUMENT"
-    page.save()
-    page.refresh_from_db()
-    assert page.documents.count() == 0
-    assert page.item_type == "PDF_DOCUMENT"
-
-    with pytest.raises(ValidationError) as c:
-        before_publish_page(request_with_user, page)
-
-    assert (
-        "a PDF_DOCUMENT content item must have at least one document "
-        "attached before publication"
-    ) in str(c.value.messages)
 
 
 def test_before_publish_non_content_item_page(request_with_user):

--- a/mycarehub/content/wagtail_hooks.py
+++ b/mycarehub/content/wagtail_hooks.py
@@ -1,5 +1,6 @@
-from django.core.exceptions import ValidationError
+from django.shortcuts import redirect
 from django.utils.safestring import mark_safe
+from wagtail.admin import messages
 from wagtail.core import hooks
 from wagtail.documents import get_document_model
 from wagtail.images import get_image_model
@@ -46,14 +47,16 @@ def before_publish_page(request, page):
                 "an AUDIO_VIDEO content item must have at least one video "
                 "or audio file before publication"
             )
-            raise ValidationError(message)
+            messages.error(request, message)
+            return redirect("wagtailadmin_pages:edit", page.pk)
 
         if page.item_type == "PDF_DOCUMENT" and page.documents.count() == 0:
             message = (
                 "a PDF_DOCUMENT content item must have at least one document "
                 "attached before publication"
             )
-            raise ValidationError(message)
+            messages.error(request, message)
+            return redirect("wagtailadmin_pages:edit", page.pk)
 
 
 @hooks.register("after_create_page")


### PR DESCRIPTION
- when the content item type is AUDIO_VIDEO or PDF_DOCUMENT, and the relevant media/document type is not attached, return form error message rather than INTERNAL server error(500)